### PR TITLE
feat: integrate Monaco Editor with file explorer and version history

### DIFF
--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -15,6 +15,7 @@ model Project {
   updatedAt   DateTime    @updatedAt
   tasks       Task[]
   aiPlanLogs  AiPlanLog[]
+  files       ProjectFile[]
 
   @@map("projects")
 }
@@ -48,6 +49,39 @@ model AiPlanLog {
   createdAt   DateTime @default(now())
 
   @@map("ai_plan_logs")
+}
+
+// ── File storage ─────────────────────────────────────────────────────────────
+model ProjectFile {
+  id        String        @id @default(cuid())
+  projectId String
+  project   Project       @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  path      String        // e.g. "src/index.ts"
+  name      String        // filename only, e.g. "index.ts"
+  language  String        @default("plaintext")
+  content   String        @default("")
+  size      Int           @default(0) // bytes
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+  versions  FileVersion[]
+
+  @@unique([projectId, path])
+  @@index([projectId])
+  @@map("project_files")
+}
+
+// Lightweight version history — stores full content snapshots
+model FileVersion {
+  id        String      @id @default(cuid())
+  fileId    String
+  file      ProjectFile @relation(fields: [fileId], references: [id], onDelete: Cascade)
+  content   String
+  size      Int
+  label     String?     // optional human label, e.g. "before refactor"
+  createdAt DateTime    @default(now())
+
+  @@index([fileId, createdAt])
+  @@map("file_versions")
 }
 
 // Persists every agent execution — input, output, status, duration

--- a/apps/server/src/agents/agent.dispatcher.ts
+++ b/apps/server/src/agents/agent.dispatcher.ts
@@ -12,6 +12,55 @@ const PIPELINE_ORDER: AgentType[] = [
   AgentType.CODE_REVIEWER,
 ];
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function persistArtifacts(
+  projectId: string,
+  results: DispatchResult[],
+): Promise<void> {
+  for (const result of results) {
+    if (result.status !== "COMPLETED" || !result.result) continue;
+    for (const artifact of result.result.artifacts) {
+      const path = artifact.filename;
+      const existing = await prisma.projectFile.findUnique({
+        where: { projectId_path: { projectId, path } },
+      });
+      if (existing) {
+        // Snapshot old content then overwrite
+        if (existing.content) {
+          await prisma.fileVersion.create({
+            data: {
+              fileId: existing.id,
+              content: existing.content,
+              size: existing.size,
+              label: `Before agent overwrite (${result.agentType})`,
+            },
+          });
+        }
+        await prisma.projectFile.update({
+          where: { id: existing.id },
+          data: {
+            content: artifact.content,
+            size: Buffer.byteLength(artifact.content, "utf8"),
+            language: artifact.language ?? "plaintext",
+          },
+        });
+      } else {
+        await prisma.projectFile.create({
+          data: {
+            projectId,
+            path,
+            name: artifact.filename,
+            language: artifact.language ?? "plaintext",
+            content: artifact.content,
+            size: Buffer.byteLength(artifact.content, "utf8"),
+          },
+        });
+      }
+    }
+  }
+}
+
 // ── Single agent dispatch ─────────────────────────────────────────────────────
 
 export async function dispatchAgent(
@@ -222,6 +271,11 @@ export async function dispatchPipeline(taskId: string): Promise<DispatchResult[]
     message: `Pipeline completed for "${task.title}" — all ${results.length} agents passed`,
     timestamp: new Date().toISOString(),
   });
+
+  // Persist all generated artifacts as project files
+  await persistArtifacts(projectId, results).catch((err) =>
+    logger.error("Failed to persist artifacts", { taskId, error: (err as Error).message }),
+  );
 
   logger.info("Pipeline completed", { taskId, stages: results.length });
   return results;

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -12,6 +12,7 @@ import tasksRouter from "./modules/tasks/tasks.router";
 import aiRouter from "./modules/ai/ai.router";
 import agentsRouter from "./agents/agent.router";
 import observabilityRouter from "./modules/observability/observability.router";
+import filesRouter from "./modules/files/files.router";
 import { bootstrapAgents } from "./agents/agent.service";
 import { taskQueue, taskQueueEvents } from "./queue/queue";
 
@@ -30,6 +31,7 @@ app.use("/api/tasks", tasksRouter);
 app.use("/api/ai", aiRouter);
 app.use("/api/agents", agentsRouter);
 app.use("/api/observe", observabilityRouter);
+app.use("/api/files", filesRouter);
 
 // ── Health ───────────────────────────────────────────────────────────────────
 app.get("/health", async (_req, res) => {

--- a/apps/server/src/modules/files/files.controller.ts
+++ b/apps/server/src/modules/files/files.controller.ts
@@ -1,0 +1,66 @@
+import { NextFunction, Request, Response } from "express";
+import * as filesService from "./files.service";
+import { createFileSchema, updateFileSchema, renameFileSchema } from "./files.schema";
+
+export async function listFiles(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { projectId } = req.query;
+    if (typeof projectId !== "string") {
+      res.status(400).json({ error: "projectId query param is required" });
+      return;
+    }
+    res.json(await filesService.listFiles(projectId));
+  } catch (err) { next(err); }
+}
+
+export async function getFile(req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json(await filesService.getFile(req.params.id));
+  } catch (err) { next(err); }
+}
+
+export async function createFile(req: Request, res: Response, next: NextFunction) {
+  try {
+    const data = createFileSchema.parse(req.body);
+    res.status(201).json(await filesService.createFile(data));
+  } catch (err) { next(err); }
+}
+
+export async function updateFile(req: Request, res: Response, next: NextFunction) {
+  try {
+    const data = updateFileSchema.parse(req.body);
+    res.json(await filesService.updateFile(req.params.id, data));
+  } catch (err) { next(err); }
+}
+
+export async function renameFile(req: Request, res: Response, next: NextFunction) {
+  try {
+    const data = renameFileSchema.parse(req.body);
+    res.json(await filesService.renameFile(req.params.id, data));
+  } catch (err) { next(err); }
+}
+
+export async function deleteFile(req: Request, res: Response, next: NextFunction) {
+  try {
+    await filesService.deleteFile(req.params.id);
+    res.status(204).send();
+  } catch (err) { next(err); }
+}
+
+export async function listVersions(req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json(await filesService.listVersions(req.params.id));
+  } catch (err) { next(err); }
+}
+
+export async function getVersion(req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json(await filesService.getVersion(req.params.versionId));
+  } catch (err) { next(err); }
+}
+
+export async function restoreVersion(req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json(await filesService.restoreVersion(req.params.id, req.params.versionId));
+  } catch (err) { next(err); }
+}

--- a/apps/server/src/modules/files/files.router.ts
+++ b/apps/server/src/modules/files/files.router.ts
@@ -1,0 +1,26 @@
+import { Router } from "express";
+import * as ctrl from "./files.controller";
+
+const router = Router();
+
+// GET    /api/files?projectId=xxx   — list files (metadata only, no content)
+// POST   /api/files                 — create file
+// GET    /api/files/:id             — get file with content
+// PATCH  /api/files/:id             — save content
+// PATCH  /api/files/:id/rename      — rename / move
+// DELETE /api/files/:id             — delete
+// GET    /api/files/:id/versions    — list version history
+// GET    /api/files/:id/versions/:versionId — get version content
+// POST   /api/files/:id/versions/:versionId/restore — restore version
+
+router.get("/", ctrl.listFiles);
+router.post("/", ctrl.createFile);
+router.get("/:id", ctrl.getFile);
+router.patch("/:id", ctrl.updateFile);
+router.patch("/:id/rename", ctrl.renameFile);
+router.delete("/:id", ctrl.deleteFile);
+router.get("/:id/versions", ctrl.listVersions);
+router.get("/:id/versions/:versionId", ctrl.getVersion);
+router.post("/:id/versions/:versionId/restore", ctrl.restoreVersion);
+
+export default router;

--- a/apps/server/src/modules/files/files.schema.ts
+++ b/apps/server/src/modules/files/files.schema.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+export const createFileSchema = z.object({
+  projectId: z.string().cuid("Invalid project ID"),
+  path: z
+    .string()
+    .min(1)
+    .max(500)
+    .transform((p) => p.replace(/\\/g, "/")),
+  name: z.string().min(1).max(255),
+  language: z.string().max(50).optional().default("plaintext"),
+  content: z.string().max(5_000_000).optional().default(""),
+});
+
+export const updateFileSchema = z.object({
+  content: z.string().max(5_000_000),
+  createVersion: z.boolean().optional().default(false),
+  versionLabel: z.string().max(100).optional(),
+});
+
+export const renameFileSchema = z.object({
+  path: z
+    .string()
+    .min(1)
+    .max(500)
+    .transform((p) => p.replace(/\\/g, "/")),
+  name: z.string().min(1).max(255),
+});
+
+export type CreateFileInput = z.infer<typeof createFileSchema>;
+export type UpdateFileInput = z.infer<typeof updateFileSchema>;
+export type RenameFileInput = z.infer<typeof renameFileSchema>;

--- a/apps/server/src/modules/files/files.service.ts
+++ b/apps/server/src/modules/files/files.service.ts
@@ -1,0 +1,163 @@
+import { prisma } from "../../lib/prisma";
+import { notFound, badRequest } from "../../lib/errors";
+import { CreateFileInput, UpdateFileInput, RenameFileInput } from "./files.schema";
+
+const MAX_VERSIONS = 50;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function detectLanguage(filename: string): string {
+  const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+  const map: Record<string, string> = {
+    ts: "typescript", tsx: "typescript",
+    js: "javascript", jsx: "javascript",
+    json: "json", md: "markdown",
+    css: "css", html: "html",
+    py: "python", rs: "rust",
+    go: "go", sh: "shell",
+    yaml: "yaml", yml: "yaml",
+    toml: "toml", sql: "sql",
+    prisma: "prisma", env: "plaintext",
+  };
+  return map[ext] ?? "plaintext";
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export async function listFiles(projectId: string) {
+  const project = await prisma.project.findUnique({ where: { id: projectId }, select: { id: true } });
+  if (!project) throw notFound("Project");
+
+  return prisma.projectFile.findMany({
+    where: { projectId },
+    orderBy: { path: "asc" },
+    select: {
+      id: true, path: true, name: true, language: true,
+      size: true, createdAt: true, updatedAt: true,
+      _count: { select: { versions: true } },
+    },
+  });
+}
+
+export async function getFile(id: string) {
+  const file = await prisma.projectFile.findUnique({ where: { id } });
+  if (!file) throw notFound("File");
+  return file;
+}
+
+export async function createFile(data: CreateFileInput) {
+  const project = await prisma.project.findUnique({ where: { id: data.projectId }, select: { id: true } });
+  if (!project) throw notFound("Project");
+
+  const existing = await prisma.projectFile.findUnique({
+    where: { projectId_path: { projectId: data.projectId, path: data.path } },
+  });
+  if (existing) throw badRequest(`A file already exists at "${data.path}"`);
+
+  const language = data.language !== "plaintext" ? data.language : detectLanguage(data.name);
+
+  return prisma.projectFile.create({
+    data: {
+      projectId: data.projectId,
+      path: data.path,
+      name: data.name,
+      language,
+      content: data.content,
+      size: Buffer.byteLength(data.content, "utf8"),
+    },
+  });
+}
+
+export async function updateFile(id: string, data: UpdateFileInput) {
+  const file = await prisma.projectFile.findUnique({ where: { id } });
+  if (!file) throw notFound("File");
+
+  return prisma.$transaction(async (tx) => {
+    // Snapshot current content as a version if requested
+    if (data.createVersion && file.content) {
+      const versionCount = await tx.fileVersion.count({ where: { fileId: id } });
+
+      // Prune oldest versions beyond the cap
+      if (versionCount >= MAX_VERSIONS) {
+        const oldest = await tx.fileVersion.findMany({
+          where: { fileId: id },
+          orderBy: { createdAt: "asc" },
+          take: versionCount - MAX_VERSIONS + 1,
+          select: { id: true },
+        });
+        await tx.fileVersion.deleteMany({ where: { id: { in: oldest.map((v) => v.id) } } });
+      }
+
+      await tx.fileVersion.create({
+        data: {
+          fileId: id,
+          content: file.content,
+          size: file.size,
+          label: data.versionLabel ?? null,
+        },
+      });
+    }
+
+    return tx.projectFile.update({
+      where: { id },
+      data: {
+        content: data.content,
+        size: Buffer.byteLength(data.content, "utf8"),
+      },
+    });
+  });
+}
+
+export async function renameFile(id: string, data: RenameFileInput) {
+  const file = await prisma.projectFile.findUnique({ where: { id } });
+  if (!file) throw notFound("File");
+
+  const conflict = await prisma.projectFile.findUnique({
+    where: { projectId_path: { projectId: file.projectId, path: data.path } },
+  });
+  if (conflict && conflict.id !== id) throw badRequest(`A file already exists at "${data.path}"`);
+
+  const language = detectLanguage(data.name);
+
+  return prisma.projectFile.update({
+    where: { id },
+    data: { path: data.path, name: data.name, language },
+  });
+}
+
+export async function deleteFile(id: string) {
+  const file = await prisma.projectFile.findUnique({ where: { id } });
+  if (!file) throw notFound("File");
+  await prisma.projectFile.delete({ where: { id } });
+}
+
+export async function listVersions(fileId: string) {
+  const file = await prisma.projectFile.findUnique({ where: { id: fileId }, select: { id: true } });
+  if (!file) throw notFound("File");
+
+  return prisma.fileVersion.findMany({
+    where: { fileId },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, size: true, label: true, createdAt: true },
+  });
+}
+
+export async function getVersion(versionId: string) {
+  const version = await prisma.fileVersion.findUnique({ where: { id: versionId } });
+  if (!version) throw notFound("FileVersion");
+  return version;
+}
+
+export async function restoreVersion(fileId: string, versionId: string) {
+  const file = await prisma.projectFile.findUnique({ where: { id: fileId } });
+  if (!file) throw notFound("File");
+
+  const version = await prisma.fileVersion.findUnique({ where: { id: versionId } });
+  if (!version || version.fileId !== fileId) throw notFound("FileVersion");
+
+  return updateFile(fileId, {
+    content: version.content,
+    createVersion: true,
+    versionLabel: `Before restore to ${version.createdAt.toISOString()}`,
+  });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@adw/ui": "*",
+    "@monaco-editor/react": "^4.6.0",
     "@xyflow/react": "^12.0.0",
     "dagre": "^0.8.5",
     "next": "^14.0.0",

--- a/apps/web/src/app/editor/page.tsx
+++ b/apps/web/src/app/editor/page.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { api } from "@/lib/api";
+import { useFileTree } from "@/lib/useFileTree";
+import { FileExplorer } from "@/components/editor/FileExplorer";
+import { EditorPane } from "@/components/editor/EditorPane";
+import { RenameModal } from "@/components/editor/RenameModal";
+import type { Project, ProjectFile } from "@/types";
+
+export default function EditorPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const projectIdParam = searchParams.get("projectId") ?? "";
+
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState(projectIdParam);
+  const [activeFile, setActiveFile] = useState<ProjectFile | null>(null);
+  const [renameTarget, setRenameTarget] = useState<ProjectFile | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const { tree, loading, refresh, addFile, updateFile, removeFile } =
+    useFileTree(selectedProjectId || null);
+
+  // Load projects for the selector
+  useEffect(() => {
+    api.projects.list().then(setProjects).catch(() => null);
+  }, []);
+
+  function handleProjectChange(id: string) {
+    setSelectedProjectId(id);
+    setActiveFile(null);
+    const p = new URLSearchParams();
+    if (id) p.set("projectId", id);
+    router.replace(`/editor?${p.toString()}`);
+  }
+
+  // Create a new file
+  const handleNewFile = useCallback(async (path: string, name: string) => {
+    if (!selectedProjectId) return;
+    try {
+      const file = await api.files.create({ projectId: selectedProjectId, path, name });
+      addFile(file);
+      setActiveFile(file);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to create file");
+    }
+  }, [selectedProjectId, addFile]);
+
+  // Delete a file
+  const handleDelete = useCallback(async (file: ProjectFile) => {
+    if (!confirm(`Delete "${file.path}"?`)) return;
+    setDeleteError(null);
+    try {
+      await api.files.delete(file.id);
+      removeFile(file.id);
+      if (activeFile?.id === file.id) setActiveFile(null);
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : "Delete failed");
+    }
+  }, [activeFile, removeFile]);
+
+  // Rename a file
+  const handleRenameConfirm = useCallback(async (path: string, name: string) => {
+    if (!renameTarget) return;
+    try {
+      const updated = await api.files.rename(renameTarget.id, { path, name });
+      updateFile(updated);
+      if (activeFile?.id === updated.id) setActiveFile(updated);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Rename failed");
+    } finally {
+      setRenameTarget(null);
+    }
+  }, [renameTarget, activeFile, updateFile]);
+
+  // When a file is saved, sync the tree metadata
+  const handleSaved = useCallback((file: ProjectFile) => {
+    updateFile(file);
+    setActiveFile(file);
+  }, [updateFile]);
+
+  // When a file is selected, fetch full content if not already loaded
+  const handleSelect = useCallback(async (file: ProjectFile) => {
+    if (file.content !== undefined && file.content !== null) {
+      setActiveFile(file);
+      return;
+    }
+    try {
+      const full = await api.files.get(file.id);
+      updateFile(full);
+      setActiveFile(full);
+    } catch {
+      setActiveFile(file);
+    }
+  }, [updateFile]);
+
+  return (
+    <div className="flex h-[calc(100vh-57px)] flex-col bg-gray-900">
+      {/* ── Top bar ── */}
+      <div className="flex items-center gap-3 border-b border-gray-700/60 bg-gray-900 px-4 py-2">
+        <select
+          value={selectedProjectId}
+          onChange={(e) => handleProjectChange(e.target.value)}
+          className="rounded border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-gray-300 focus:border-blue-500 focus:outline-none"
+        >
+          <option value="">Select a project…</option>
+          {projects.map((p) => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+
+        {selectedProjectId && (
+          <button
+            onClick={refresh}
+            className="rounded border border-gray-700 px-2.5 py-1.5 text-xs text-gray-500 hover:bg-gray-700/60 hover:text-gray-300"
+          >
+            ↺ Refresh
+          </button>
+        )}
+
+        {deleteError && (
+          <span className="text-xs text-red-400">{deleteError}</span>
+        )}
+      </div>
+
+      {/* ── Main layout: sidebar + editor ── */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* File explorer sidebar */}
+        <div className="w-56 shrink-0 border-r border-gray-700/60">
+          {selectedProjectId ? (
+            <FileExplorer
+              tree={tree}
+              selectedId={activeFile?.id ?? null}
+              onSelect={handleSelect}
+              onNewFile={handleNewFile}
+              onDelete={handleDelete}
+              onRename={setRenameTarget}
+              loading={loading}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <p className="px-4 text-center text-[12px] text-gray-600">
+                Select a project to browse files
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Monaco editor pane */}
+        <div className="flex-1 overflow-hidden">
+          <EditorPane file={activeFile} onSaved={handleSaved} />
+        </div>
+      </div>
+
+      {/* Rename modal */}
+      {renameTarget && (
+        <RenameModal
+          file={renameTarget}
+          onConfirm={handleRenameConfirm}
+          onCancel={() => setRenameTarget(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -8,6 +8,7 @@ const links = [
   { href: "/projects", label: "Projects" },
   { href: "/tasks", label: "Tasks" },
   { href: "/graph", label: "Graph" },
+  { href: "/editor", label: "Editor" },
   { href: "/observe", label: "Observe" },
 ];
 

--- a/apps/web/src/components/editor/EditorPane.tsx
+++ b/apps/web/src/components/editor/EditorPane.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useRef, useCallback, useState, useEffect } from "react";
+import dynamic from "next/dynamic";
+import type { OnMount } from "@monaco-editor/react";
+import type { ProjectFile, FileVersionMeta, FileVersion } from "@/types";
+import { api } from "@/lib/api";
+
+const MonacoEditor = dynamic(() => import("@monaco-editor/react"), { ssr: false });
+
+// ── Tab bar ───────────────────────────────────────────────────────────────────
+
+interface TabBarProps {
+  tabs: OpenTab[];
+  activeId: string | null;
+  onActivate: (id: string) => void;
+  onClose: (id: string) => void;
+}
+
+interface OpenTab {
+  id: string;
+  name: string;
+  dirty: boolean;
+}
+
+function TabBar({ tabs, activeId, onActivate, onClose }: TabBarProps) {
+  if (tabs.length === 0) return null;
+  return (
+    <div className="flex overflow-x-auto border-b border-gray-700/60 bg-gray-900 scrollbar-none">
+      {tabs.map((tab) => (
+        <div
+          key={tab.id}
+          onClick={() => onActivate(tab.id)}
+          className={`group flex shrink-0 cursor-pointer items-center gap-1.5 border-r border-gray-700/40 px-3 py-2 text-[12px] transition-colors
+            ${activeId === tab.id
+              ? "bg-gray-800 text-gray-100 border-t-2 border-t-blue-500"
+              : "text-gray-500 hover:bg-gray-800/50 hover:text-gray-300"
+            }`}
+        >
+          <span className="max-w-[120px] truncate">{tab.name}</span>
+          {tab.dirty && <span className="h-1.5 w-1.5 rounded-full bg-orange-400" title="Unsaved changes" />}
+          <button
+            onClick={(e) => { e.stopPropagation(); onClose(tab.id); }}
+            className="ml-0.5 rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-gray-600"
+          >
+            <svg className="h-3 w-3" viewBox="0 0 12 12" fill="currentColor">
+              <path d="M2.22 2.22a.75.75 0 011.06 0L6 4.94l2.72-2.72a.75.75 0 111.06 1.06L7.06 6l2.72 2.72a.75.75 0 11-1.06 1.06L6 7.06 3.28 9.78a.75.75 0 01-1.06-1.06L4.94 6 2.22 3.28a.75.75 0 010-1.06z" />
+            </svg>
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Version history panel ─────────────────────────────────────────────────────
+
+interface VersionPanelProps {
+  fileId: string;
+  onRestore: (content: string) => void;
+  onClose: () => void;
+}
+
+function VersionPanel({ fileId, onRestore, onClose }: VersionPanelProps) {
+  const [versions, setVersions] = useState<FileVersionMeta[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [restoring, setRestoring] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.files.listVersions(fileId)
+      .then(setVersions)
+      .catch(() => null)
+      .finally(() => setLoading(false));
+  }, [fileId]);
+
+  async function handleRestore(versionId: string) {
+    setRestoring(versionId);
+    try {
+      const v = await api.files.getVersion(fileId, versionId) as FileVersion;
+      onRestore(v.content);
+    } finally {
+      setRestoring(null);
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col border-l border-gray-700/60 bg-gray-900 w-64 shrink-0">
+      <div className="flex items-center justify-between border-b border-gray-700/60 px-3 py-2">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500">
+          Version History
+        </span>
+        <button onClick={onClose} className="text-gray-600 hover:text-gray-400">
+          <svg className="h-4 w-4" viewBox="0 0 12 12" fill="currentColor">
+            <path d="M2.22 2.22a.75.75 0 011.06 0L6 4.94l2.72-2.72a.75.75 0 111.06 1.06L7.06 6l2.72 2.72a.75.75 0 11-1.06 1.06L6 7.06 3.28 9.78a.75.75 0 01-1.06-1.06L4.94 6 2.22 3.28a.75.75 0 010-1.06z" />
+          </svg>
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <p className="px-3 py-4 text-[12px] text-gray-600">Loading…</p>
+        ) : versions.length === 0 ? (
+          <p className="px-3 py-4 text-[12px] text-gray-600">No versions yet. Save with "Save Version" to create one.</p>
+        ) : (
+          versions.map((v) => (
+            <div key={v.id} className="border-b border-gray-800 px-3 py-2.5">
+              <p className="text-[12px] text-gray-300">
+                {new Date(v.createdAt).toLocaleString()}
+              </p>
+              {v.label && <p className="mt-0.5 text-[11px] text-gray-500 truncate">{v.label}</p>}
+              <p className="mt-0.5 text-[11px] text-gray-600">{(v.size / 1024).toFixed(1)} KB</p>
+              <button
+                onClick={() => handleRestore(v.id)}
+                disabled={restoring === v.id}
+                className="mt-1.5 rounded bg-gray-700 px-2 py-0.5 text-[11px] text-gray-300 hover:bg-gray-600 disabled:opacity-50"
+              >
+                {restoring === v.id ? "Restoring…" : "Restore"}
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Main EditorPane ───────────────────────────────────────────────────────────
+
+export interface EditorPaneProps {
+  file: ProjectFile | null;
+  onSaved: (file: ProjectFile) => void;
+}
+
+export function EditorPane({ file, onSaved }: EditorPaneProps) {
+  // Per-file content buffer (tracks unsaved edits)
+  const contentMap = useRef<Map<string, string>>(new Map());
+  const [tabs, setTabs] = useState<OpenTab[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [showVersions, setShowVersions] = useState(false);
+  const [versionRestoreKey, setVersionRestoreKey] = useState(0);
+
+  // When a new file is selected externally, open it as a tab
+  useEffect(() => {
+    if (!file) return;
+    setTabs((prev) => {
+      if (prev.find((t) => t.id === file.id)) return prev;
+      return [...prev, { id: file.id, name: file.name, dirty: false }];
+    });
+    setActiveId(file.id);
+    // Seed content buffer if not already there
+    if (!contentMap.current.has(file.id)) {
+      contentMap.current.set(file.id, file.content);
+    }
+    setSaveError(null);
+  }, [file]);
+
+  const activeFile = file?.id === activeId ? file : null;
+  const activeContent = activeId ? (contentMap.current.get(activeId) ?? "") : "";
+
+  const handleEditorChange = useCallback((value: string | undefined) => {
+    if (!activeId) return;
+    const newVal = value ?? "";
+    contentMap.current.set(activeId, newVal);
+    setTabs((prev) =>
+      prev.map((t) =>
+        t.id === activeId
+          ? { ...t, dirty: newVal !== (file?.content ?? "") }
+          : t,
+      ),
+    );
+  }, [activeId, file]);
+
+  const handleSave = useCallback(async (createVersion = false) => {
+    if (!activeId || !activeFile) return;
+    const content = contentMap.current.get(activeId) ?? "";
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const updated = await api.files.update(activeId, { content, createVersion });
+      contentMap.current.set(activeId, updated.content);
+      setTabs((prev) => prev.map((t) => (t.id === activeId ? { ...t, dirty: false } : t)));
+      onSaved(updated);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }, [activeId, activeFile, onSaved]);
+
+  // Ctrl/Cmd+S to save
+  const handleEditorMount: OnMount = useCallback((editor) => {
+    editor.addCommand(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).monaco?.KeyMod?.CtrlCmd | (window as any).monaco?.KeyCode?.KeyS ?? 2097,
+      () => handleSave(false),
+    );
+  }, [handleSave]);
+
+  const handleCloseTab = useCallback((id: string) => {
+    setTabs((prev) => {
+      const next = prev.filter((t) => t.id !== id);
+      if (activeId === id) {
+        setActiveId(next[next.length - 1]?.id ?? null);
+      }
+      return next;
+    });
+    contentMap.current.delete(id);
+  }, [activeId]);
+
+  const handleVersionRestore = useCallback((content: string) => {
+    if (!activeId) return;
+    contentMap.current.set(activeId, content);
+    setVersionRestoreKey((k) => k + 1); // force Monaco remount with new value
+    setTabs((prev) =>
+      prev.map((t) => (t.id === activeId ? { ...t, dirty: true } : t)),
+    );
+    setShowVersions(false);
+  }, [activeId]);
+
+  if (tabs.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center bg-gray-900 text-gray-600">
+        <svg className="mb-3 h-10 w-10 opacity-30" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+        </svg>
+        <p className="text-[13px]">Select a file to start editing</p>
+      </div>
+    );
+  }
+
+  const activeTab = tabs.find((t) => t.id === activeId);
+
+  return (
+    <div className="flex h-full flex-col bg-gray-900">
+      {/* Tab bar */}
+      <TabBar
+        tabs={tabs}
+        activeId={activeId}
+        onActivate={setActiveId}
+        onClose={handleCloseTab}
+      />
+
+      {/* Toolbar */}
+      <div className="flex items-center justify-between border-b border-gray-700/60 bg-gray-900 px-3 py-1.5">
+        <span className="text-[12px] text-gray-500">
+          {activeFile?.path ?? ""}
+        </span>
+        <div className="flex items-center gap-2">
+          {saveError && (
+            <span className="text-[11px] text-red-400">{saveError}</span>
+          )}
+          <button
+            onClick={() => setShowVersions((v) => !v)}
+            className={`rounded px-2 py-1 text-[11px] transition-colors ${
+              showVersions
+                ? "bg-gray-700 text-gray-200"
+                : "text-gray-500 hover:bg-gray-700/60 hover:text-gray-300"
+            }`}
+          >
+            History
+          </button>
+          <button
+            onClick={() => handleSave(true)}
+            disabled={saving || !activeTab?.dirty}
+            className="rounded px-2 py-1 text-[11px] text-gray-400 hover:bg-gray-700/60 hover:text-gray-300 disabled:opacity-40"
+          >
+            Save Version
+          </button>
+          <button
+            onClick={() => handleSave(false)}
+            disabled={saving || !activeTab?.dirty}
+            className="rounded bg-blue-600 px-3 py-1 text-[11px] font-medium text-white hover:bg-blue-500 disabled:opacity-40"
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+
+      {/* Editor + version panel */}
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex-1 overflow-hidden">
+          {activeFile && (
+            <MonacoEditor
+              key={`${activeId}-${versionRestoreKey}`}
+              height="100%"
+              language={activeFile.language}
+              value={activeContent}
+              theme="vs-dark"
+              onChange={handleEditorChange}
+              onMount={handleEditorMount}
+              options={{
+                fontSize: 13,
+                fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace",
+                fontLigatures: true,
+                minimap: { enabled: true, scale: 1 },
+                scrollBeyondLastLine: false,
+                wordWrap: "on",
+                tabSize: 2,
+                insertSpaces: true,
+                renderWhitespace: "selection",
+                smoothScrolling: true,
+                cursorBlinking: "smooth",
+                cursorSmoothCaretAnimation: "on",
+                bracketPairColorization: { enabled: true },
+                guides: { bracketPairs: true, indentation: true },
+                padding: { top: 12, bottom: 12 },
+                lineNumbers: "on",
+                glyphMargin: false,
+                folding: true,
+                automaticLayout: true,
+              }}
+            />
+          )}
+        </div>
+
+        {showVersions && activeId && (
+          <VersionPanel
+            fileId={activeId}
+            onRestore={handleVersionRestore}
+            onClose={() => setShowVersions(false)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/editor/FileExplorer.tsx
+++ b/apps/web/src/components/editor/FileExplorer.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import type { FileNode } from "@/lib/useFileTree";
+import type { ProjectFile } from "@/types";
+
+// ── Icons (inline SVG to avoid extra deps) ────────────────────────────────────
+
+function FolderIcon({ open }: { open: boolean }) {
+  return (
+    <svg className="h-3.5 w-3.5 shrink-0 text-yellow-500" viewBox="0 0 16 16" fill="currentColor">
+      {open ? (
+        <path d="M1.5 3A1.5 1.5 0 000 4.5v8A1.5 1.5 0 001.5 14h13a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H7.621a1.5 1.5 0 01-1.06-.44L5.5 3H1.5z" />
+      ) : (
+        <path d="M.54 3.87L.5 3a2 2 0 012-2h3.672a2 2 0 011.414.586l.828.828A2 2 0 009.828 3h3.982a2 2 0 011.992 2.181l-.637 7A2 2 0 0113.174 14H2.826a2 2 0 01-1.991-1.819l-.637-7a1.99 1.99 0 01.342-1.31z" />
+      )}
+    </svg>
+  );
+}
+
+function FileIcon({ language }: { language: string }) {
+  const colors: Record<string, string> = {
+    typescript: "text-blue-400", javascript: "text-yellow-400",
+    python: "text-green-400", json: "text-orange-400",
+    markdown: "text-gray-400", css: "text-pink-400",
+    html: "text-red-400", rust: "text-orange-500",
+    go: "text-cyan-400", sql: "text-purple-400",
+  };
+  const color = colors[language] ?? "text-gray-500";
+  return (
+    <svg className={`h-3.5 w-3.5 shrink-0 ${color}`} viewBox="0 0 16 16" fill="currentColor">
+      <path d="M4 0a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V4.414A2 2 0 0013.414 3L11 .586A2 2 0 009.586 0H4zm0 1.5h5.586L12 3.914V14a.5.5 0 01-.5.5h-7A.5.5 0 014 14V2a.5.5 0 01.5-.5H4z" />
+    </svg>
+  );
+}
+
+// ── Tree node ─────────────────────────────────────────────────────────────────
+
+interface TreeNodeProps {
+  node: FileNode;
+  depth: number;
+  selectedId: string | null;
+  onSelect: (file: ProjectFile) => void;
+  onDelete: (file: ProjectFile) => void;
+  onRename: (file: ProjectFile) => void;
+}
+
+function TreeNode({ node, depth, selectedId, onSelect, onDelete, onRename }: TreeNodeProps) {
+  const [open, setOpen] = useState(true);
+  const [ctxPos, setCtxPos] = useState<{ x: number; y: number } | null>(null);
+  const isSelected = node.type === "file" && node.file?.id === selectedId;
+
+  const handleContext = useCallback((e: React.MouseEvent) => {
+    if (node.type !== "file") return;
+    e.preventDefault();
+    setCtxPos({ x: e.clientX, y: e.clientY });
+  }, [node.type]);
+
+  const closeCtx = useCallback(() => setCtxPos(null), []);
+
+  return (
+    <div>
+      <div
+        className={`group flex cursor-pointer items-center gap-1.5 rounded px-2 py-[3px] text-[13px] transition-colors
+          ${isSelected ? "bg-blue-600 text-white" : "text-gray-300 hover:bg-gray-700/60"}`}
+        style={{ paddingLeft: `${8 + depth * 14}px` }}
+        onClick={() => {
+          if (node.type === "folder") setOpen((v) => !v);
+          else if (node.file) onSelect(node.file);
+        }}
+        onContextMenu={handleContext}
+      >
+        {node.type === "folder" ? (
+          <>
+            <span className="text-gray-500 text-[10px]">{open ? "▾" : "▸"}</span>
+            <FolderIcon open={open} />
+          </>
+        ) : (
+          <>
+            <span className="w-3" />
+            <FileIcon language={node.file?.language ?? "plaintext"} />
+          </>
+        )}
+        <span className="truncate">{node.name}</span>
+      </div>
+
+      {/* Context menu */}
+      {ctxPos && node.file && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={closeCtx} />
+          <div
+            className="fixed z-50 min-w-[140px] rounded-md border border-gray-700 bg-gray-800 py-1 shadow-xl text-[13px]"
+            style={{ top: ctxPos.y, left: ctxPos.x }}
+          >
+            <button
+              className="w-full px-3 py-1.5 text-left text-gray-300 hover:bg-gray-700"
+              onClick={() => { onRename(node.file!); closeCtx(); }}
+            >
+              Rename
+            </button>
+            <button
+              className="w-full px-3 py-1.5 text-left text-red-400 hover:bg-gray-700"
+              onClick={() => { onDelete(node.file!); closeCtx(); }}
+            >
+              Delete
+            </button>
+          </div>
+        </>
+      )}
+
+      {node.type === "folder" && open && node.children?.map((child) => (
+        <TreeNode
+          key={child.path}
+          node={child}
+          depth={depth + 1}
+          selectedId={selectedId}
+          onSelect={onSelect}
+          onDelete={onDelete}
+          onRename={onRename}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ── New file form ─────────────────────────────────────────────────────────────
+
+interface NewFileFormProps {
+  onSubmit: (path: string, name: string) => void;
+  onCancel: () => void;
+}
+
+function NewFileForm({ onSubmit, onCancel }: NewFileFormProps) {
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <form
+      className="px-2 py-1"
+      onSubmit={(e) => {
+        e.preventDefault();
+        const trimmed = value.trim();
+        if (!trimmed) return;
+        const parts = trimmed.split("/");
+        const name = parts[parts.length - 1]!;
+        onSubmit(trimmed, name);
+      }}
+    >
+      <input
+        ref={inputRef}
+        autoFocus
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="src/utils/helper.ts"
+        className="w-full rounded border border-blue-500 bg-gray-800 px-2 py-1 text-[12px] text-gray-200 outline-none placeholder-gray-600"
+        onKeyDown={(e) => e.key === "Escape" && onCancel()}
+      />
+      <div className="mt-1 flex gap-1">
+        <button type="submit" className="rounded bg-blue-600 px-2 py-0.5 text-[11px] text-white hover:bg-blue-500">
+          Create
+        </button>
+        <button type="button" onClick={onCancel} className="rounded px-2 py-0.5 text-[11px] text-gray-500 hover:text-gray-300">
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ── Main FileExplorer ─────────────────────────────────────────────────────────
+
+export interface FileExplorerProps {
+  tree: FileNode[];
+  selectedId: string | null;
+  onSelect: (file: ProjectFile) => void;
+  onNewFile: (path: string, name: string) => void;
+  onDelete: (file: ProjectFile) => void;
+  onRename: (file: ProjectFile) => void;
+  loading: boolean;
+}
+
+export function FileExplorer({
+  tree, selectedId, onSelect, onNewFile, onDelete, onRename, loading,
+}: FileExplorerProps) {
+  const [showNewForm, setShowNewForm] = useState(false);
+
+  return (
+    <div className="flex h-full flex-col bg-gray-900 select-none">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-gray-700/60 px-3 py-2">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500">
+          Explorer
+        </span>
+        <button
+          title="New file"
+          onClick={() => setShowNewForm(true)}
+          className="rounded p-0.5 text-gray-500 hover:bg-gray-700 hover:text-gray-300"
+        >
+          <svg className="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Tree */}
+      <div className="flex-1 overflow-y-auto py-1">
+        {loading ? (
+          <p className="px-3 py-4 text-[12px] text-gray-600">Loading…</p>
+        ) : tree.length === 0 && !showNewForm ? (
+          <p className="px-3 py-4 text-[12px] text-gray-600">No files yet. Click + to create one.</p>
+        ) : (
+          tree.map((node) => (
+            <TreeNode
+              key={node.path}
+              node={node}
+              depth={0}
+              selectedId={selectedId}
+              onSelect={onSelect}
+              onDelete={onDelete}
+              onRename={onRename}
+            />
+          ))
+        )}
+
+        {showNewForm && (
+          <NewFileForm
+            onSubmit={(path, name) => { onNewFile(path, name); setShowNewForm(false); }}
+            onCancel={() => setShowNewForm(false)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/editor/RenameModal.tsx
+++ b/apps/web/src/components/editor/RenameModal.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import type { ProjectFile } from "@/types";
+
+interface RenameModalProps {
+  file: ProjectFile;
+  onConfirm: (path: string, name: string) => void;
+  onCancel: () => void;
+}
+
+export function RenameModal({ file, onConfirm, onCancel }: RenameModalProps) {
+  const [value, setValue] = useState(file.path);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.select();
+  }, []);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    const parts = trimmed.split("/");
+    const name = parts[parts.length - 1]!;
+    onConfirm(trimmed, name);
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="w-96 rounded-lg border border-gray-700 bg-gray-800 p-5 shadow-2xl">
+        <h3 className="mb-3 text-sm font-semibold text-gray-200">Rename / Move File</h3>
+        <form onSubmit={handleSubmit}>
+          <input
+            ref={inputRef}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            className="w-full rounded border border-gray-600 bg-gray-900 px-3 py-2 text-sm text-gray-200 outline-none focus:border-blue-500"
+            onKeyDown={(e) => e.key === "Escape" && onCancel()}
+          />
+          <div className="mt-4 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded px-3 py-1.5 text-sm text-gray-400 hover:bg-gray-700"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="rounded bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-500"
+            >
+              Rename
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -9,6 +9,12 @@ import type {
   ObsLog,
   AgentRunRow,
   TimelineRow,
+  ProjectFile,
+  FileVersionMeta,
+  FileVersion,
+  CreateFilePayload,
+  UpdateFilePayload,
+  RenameFilePayload,
 } from "@/types";
 
 const BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
@@ -65,5 +71,24 @@ export const api = {
       request<TimelineRow[]>(`/api/observe/timeline${projectId ? `?projectId=${projectId}` : ""}`),
     errors: (limit?: number) =>
       request<ObsLog[]>(`/api/observe/errors${limit ? `?limit=${limit}` : ""}`),
+  },
+  files: {
+    list: (projectId: string) =>
+      request<ProjectFile[]>(`/api/files?projectId=${projectId}`),
+    get: (id: string) => request<ProjectFile>(`/api/files/${id}`),
+    create: (data: CreateFilePayload) =>
+      request<ProjectFile>("/api/files", { method: "POST", body: JSON.stringify(data) }),
+    update: (id: string, data: UpdateFilePayload) =>
+      request<ProjectFile>(`/api/files/${id}`, { method: "PATCH", body: JSON.stringify(data) }),
+    rename: (id: string, data: RenameFilePayload) =>
+      request<ProjectFile>(`/api/files/${id}/rename`, { method: "PATCH", body: JSON.stringify(data) }),
+    delete: (id: string) =>
+      request<void>(`/api/files/${id}`, { method: "DELETE" }),
+    listVersions: (id: string) =>
+      request<FileVersionMeta[]>(`/api/files/${id}/versions`),
+    getVersion: (id: string, versionId: string) =>
+      request<FileVersion>(`/api/files/${id}/versions/${versionId}`),
+    restoreVersion: (id: string, versionId: string) =>
+      request<ProjectFile>(`/api/files/${id}/versions/${versionId}/restore`, { method: "POST" }),
   },
 };

--- a/apps/web/src/lib/useFileTree.ts
+++ b/apps/web/src/lib/useFileTree.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { api } from "./api";
+import type { ProjectFile } from "@/types";
+
+export interface FileNode {
+  type: "file" | "folder";
+  name: string;
+  path: string;
+  file?: ProjectFile;
+  children?: FileNode[];
+}
+
+function buildTree(files: ProjectFile[]): FileNode[] {
+  const root: FileNode[] = [];
+
+  for (const file of files) {
+    const parts = file.path.split("/");
+    let nodes = root;
+
+    for (let i = 0; i < parts.length - 1; i++) {
+      const folderName = parts[i]!;
+      const folderPath = parts.slice(0, i + 1).join("/");
+      let folder = nodes.find((n) => n.type === "folder" && n.name === folderName);
+      if (!folder) {
+        folder = { type: "folder", name: folderName, path: folderPath, children: [] };
+        nodes.push(folder);
+      }
+      nodes = folder.children!;
+    }
+
+    nodes.push({ type: "file", name: file.name, path: file.path, file });
+  }
+
+  // Sort: folders first, then files, both alphabetically
+  function sort(nodes: FileNode[]): FileNode[] {
+    return nodes
+      .sort((a, b) => {
+        if (a.type !== b.type) return a.type === "folder" ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      })
+      .map((n) => (n.children ? { ...n, children: sort(n.children) } : n));
+  }
+
+  return sort(root);
+}
+
+export interface UseFileTreeResult {
+  files: ProjectFile[];
+  tree: FileNode[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  addFile: (file: ProjectFile) => void;
+  updateFile: (file: ProjectFile) => void;
+  removeFile: (id: string) => void;
+}
+
+export function useFileTree(projectId: string | null): UseFileTreeResult {
+  const [files, setFiles] = useState<ProjectFile[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!projectId) { setFiles([]); return; }
+    setLoading(true);
+    setError(null);
+    try {
+      setFiles(await api.files.list(projectId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load files");
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const addFile = useCallback((file: ProjectFile) => {
+    setFiles((prev) => [...prev, file]);
+  }, []);
+
+  const updateFile = useCallback((file: ProjectFile) => {
+    setFiles((prev) => prev.map((f) => (f.id === file.id ? file : f)));
+  }, []);
+
+  const removeFile = useCallback((id: string) => {
+    setFiles((prev) => prev.filter((f) => f.id !== id));
+  }, []);
+
+  return {
+    files,
+    tree: buildTree(files),
+    loading,
+    error,
+    refresh,
+    addFile,
+    updateFile,
+    removeFile,
+  };
+}

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -113,6 +113,56 @@ export interface TimelineRow {
   stages: TimelineStage[];
 }
 
+// ── File editor ──────────────────────────────────────────────────────────────
+
+export interface ProjectFile {
+  id: string;
+  projectId: string;
+  path: string;
+  name: string;
+  language: string;
+  content: string;
+  size: number;
+  createdAt: string;
+  updatedAt: string;
+  _count?: { versions: number };
+}
+
+export interface FileVersion {
+  id: string;
+  fileId: string;
+  content: string;
+  size: number;
+  label?: string | null;
+  createdAt: string;
+}
+
+export interface FileVersionMeta {
+  id: string;
+  size: number;
+  label?: string | null;
+  createdAt: string;
+}
+
+export interface CreateFilePayload {
+  projectId: string;
+  path: string;
+  name: string;
+  language?: string;
+  content?: string;
+}
+
+export interface UpdateFilePayload {
+  content: string;
+  createVersion?: boolean;
+  versionLabel?: string;
+}
+
+export interface RenameFilePayload {
+  path: string;
+  name: string;
+}
+
 export interface SummaryStats {
   tasks: {
     total: number;


### PR DESCRIPTION
#Title: feat: Monaco Editor integration with file explorer and version history

#Description:

Adds a full in-browser code editor to the workspace, so you can actually read and edit the files your agents generate — without leaving the app.

#What's new:

Editor page (/editor) - pick a project, browse its files, and start editing immediately

File explorer sidebar - folder tree with language-colored icons, right-click to rename or delete, inline form to create new files (supports nested paths like src/utils/helper.ts)

Monaco editor - the same editor that powers VS Code, with syntax highlighting, bracket matching, minimap, and Ctrl+S to save

Multi-tab support - open several files at once, unsaved changes are tracked with an orange dot per tab

Version history- every "Save Version" snapshots the file content; you can browse and restore any past snapshot from the History panel

Auto-save from agents - when the agent pipeline completes, all generated code, tests, and review files are automatically saved into the project's file tree (with version snapshots on overwrite)

#To run after merging:

cd apps/server && npx prisma migrate dev --name add_file_storage
cd apps/web && npm install