### PR TITLE
feat: add MCP server, LRU cache, project persistence, and agent fixes

### DIFF
--- a/apps/server-py/requirements.txt
+++ b/apps/server-py/requirements.txt
@@ -8,3 +8,4 @@ firebase-admin
 groq
 slowapi
 python-multipart
+mcp[cli]>=1.0.0

--- a/apps/server-py/src/agents/agent_dispatcher.py
+++ b/apps/server-py/src/agents/agent_dispatcher.py
@@ -7,6 +7,7 @@ from src.lib.logger import logger
 from src.lib.errors import not_found
 from src.lib.utils import now_iso
 from src.lib import emitter
+from src.lib.cache import task_cache
 from src.lib.socket_events import AgentLogPayload, PipelineStagePayload, TaskUpdatedPayload
 from src.agents.agent_registry import get_agent
 from src.agents.agent_types import AgentType, AgentRunStatus, AgentContext, AgentResult
@@ -68,6 +69,18 @@ async def _persist_artifacts(project_id: str, results: list[DispatchResult]) -> 
                 })
 
 
+def _get_task(task_id: str) -> dict:
+    cached = task_cache.get(task_id)
+    if cached:
+        return cached
+    task_doc = db.collection("tasks").document(task_id).get()
+    if not task_doc.exists:
+        raise not_found("Task")
+    data = {"id": task_doc.id, **task_doc.to_dict()}
+    task_cache.set(task_id, data)
+    return data
+
+
 async def dispatch_agent(
     task_id: str,
     agent_type: AgentType,
@@ -75,10 +88,7 @@ async def dispatch_agent(
 ) -> DispatchResult:
     previous_outputs = previous_outputs or {}
 
-    task_doc = db.collection("tasks").document(task_id).get()
-    if not task_doc.exists:
-        raise not_found("Task")
-    task = {"id": task_doc.id, **task_doc.to_dict()}
+    task = _get_task(task_id)
     project_id: str = task["projectId"]
 
     ctx = AgentContext(
@@ -142,6 +152,7 @@ async def dispatch_agent(
     except Exception as err:
         duration_ms = int((time.monotonic() - started_at) * 1000)
         error_msg = str(err)
+        logger.error(f"Agent failed: run={run_ref.id} error={error_msg}", exc_info=True)
         run_ref.update({
             "status": AgentRunStatus.FAILED.value,
             "errorMsg": error_msg,
@@ -158,7 +169,6 @@ async def dispatch_agent(
             agentType=agent_type.value, level="error",
             message=f"Agent {agent_type.value} failed: {error_msg}", timestamp=ts,
         ))
-        logger.error(f"Agent failed: run={run_ref.id} error={error_msg}")
 
         return DispatchResult(
             agentRunId=run_ref.id, taskId=task_id, agentType=agent_type,
@@ -167,14 +177,13 @@ async def dispatch_agent(
 
 
 async def dispatch_pipeline(task_id: str) -> list[DispatchResult]:
-    task_doc = db.collection("tasks").document(task_id).get()
-    if not task_doc.exists:
-        raise not_found("Task")
-    task = {"id": task_doc.id, **task_doc.to_dict()}
+    task = _get_task(task_id)
     project_id: str = task["projectId"]
 
     ts = now_iso()
     db.collection("tasks").document(task_id).update({"status": "IN_PROGRESS", "updatedAt": ts})
+    task_cache.delete(task_id)  # invalidate so next read gets fresh status
+
     await emitter.emit_task_updated(TaskUpdatedPayload(
         taskId=task_id, projectId=project_id, status="IN_PROGRESS",
         title=task["title"], updatedAt=ts,
@@ -196,6 +205,7 @@ async def dispatch_pipeline(task_id: str) -> list[DispatchResult]:
         if result.status == "FAILED":
             ts = now_iso()
             db.collection("tasks").document(task_id).update({"status": "FAILED", "updatedAt": ts})
+            task_cache.delete(task_id)
             await emitter.emit_task_updated(TaskUpdatedPayload(
                 taskId=task_id, projectId=project_id, status="FAILED",
                 title=task["title"], updatedAt=ts,
@@ -208,6 +218,8 @@ async def dispatch_pipeline(task_id: str) -> list[DispatchResult]:
 
     ts = now_iso()
     db.collection("tasks").document(task_id).update({"status": "COMPLETED", "updatedAt": ts})
+    task_cache.delete(task_id)
+
     await emitter.emit_task_updated(TaskUpdatedPayload(
         taskId=task_id, projectId=project_id, status="COMPLETED",
         title=task["title"], updatedAt=ts,
@@ -222,7 +234,7 @@ async def dispatch_pipeline(task_id: str) -> list[DispatchResult]:
     try:
         await _persist_artifacts(project_id, results)
     except Exception as err:
-        logger.error(f"Failed to persist artifacts: {err}")
+        logger.error(f"Failed to persist artifacts: {err}", exc_info=True)
 
     logger.info(f"Pipeline completed: task={task_id} stages={len(results)}")
     return results

--- a/apps/server-py/src/agents/runners/code_generator.py
+++ b/apps/server-py/src/agents/runners/code_generator.py
@@ -42,13 +42,18 @@ class CodeGeneratorAgent:
     description = "Generates implementation code for a given task in the detected language."
 
     async def run(self, ctx: AgentContext) -> AgentResult:
-        # Get project language
         from src.lib.firestore import db
-        project_doc = db.collection("projects").document(ctx.projectId).get()
-        language = "python"  # default
-        if project_doc.exists:
-            project_data = project_doc.to_dict()
-            language = project_data.get("language", "python").lower()
+        from src.lib.cache import project_cache
+        cached = project_cache.get(ctx.projectId)
+        if cached:
+            language = cached.get("language", "python").lower()
+        else:
+            project_doc = db.collection("projects").document(ctx.projectId).get()
+            language = "python"
+            if project_doc.exists:
+                data = project_doc.to_dict()
+                language = data.get("language", "python").lower()
+                project_cache.set(ctx.projectId, data)
         
         extension = LANGUAGE_EXTENSIONS.get(language, ".txt")
         src_dir = LANGUAGE_DIRS.get(language, "src")
@@ -63,11 +68,13 @@ class CodeGeneratorAgent:
                 "- Include all necessary imports at the top.\n"
                 "- Add concise docstrings/comments on public functions only.\n"
                 "- Keep the implementation focused on exactly what the task describes.\n"
+                "- If the task involves UI/frontend, produce a single self-contained component file.\n"
+                "- Do NOT generate multiple files — output exactly one file's worth of code.\n"
                 "- Follow proper naming conventions for the language.\n"
                 "- Structure code with proper separation of concerns."
             )),
             LlmMessage(role="user", content=f"Task: {ctx.taskTitle}\n\nDescription: {ctx.taskDescription}\n\nProject context: {ctx.projectId}"),
-        ])
+        ], max_tokens=8192)
 
         # Create proper filename with directory structure
         base_name = re.sub(r"[^a-z0-9]+", "_", ctx.taskTitle.lower()).strip("_")[:50]

--- a/apps/server-py/src/agents/runners/code_reviewer.py
+++ b/apps/server-py/src/agents/runners/code_reviewer.py
@@ -9,13 +9,18 @@ class CodeReviewerAgent:
     description = "Reviews generated code and tests, produces a structured markdown report."
 
     async def run(self, ctx: AgentContext) -> AgentResult:
-        # Get project language for proper code fence syntax
         from src.lib.firestore import db
-        project_doc = db.collection("projects").document(ctx.projectId).get()
-        language = "python"  # default
-        if project_doc.exists:
-            project_data = project_doc.to_dict()
-            language = project_data.get("language", "python").lower()
+        from src.lib.cache import project_cache
+        cached = project_cache.get(ctx.projectId)
+        if cached:
+            language = cached.get("language", "python").lower()
+        else:
+            project_doc = db.collection("projects").document(ctx.projectId).get()
+            language = "python"
+            if project_doc.exists:
+                data = project_doc.to_dict()
+                language = data.get("language", "python").lower()
+                project_cache.set(ctx.projectId, data)
         
         def _get_artifact(agent_type: AgentType, art_type: str):
             prev = ctx.previousOutputs.get(agent_type)

--- a/apps/server-py/src/agents/runners/test_generator.py
+++ b/apps/server-py/src/agents/runners/test_generator.py
@@ -37,13 +37,18 @@ class TestGeneratorAgent:
     description = "Generates a test suite for a task, using generated code if available."
 
     async def run(self, ctx: AgentContext) -> AgentResult:
-        # Get project language
         from src.lib.firestore import db
-        project_doc = db.collection("projects").document(ctx.projectId).get()
-        language = "python"  # default
-        if project_doc.exists:
-            project_data = project_doc.to_dict()
-            language = project_data.get("language", "python").lower()
+        from src.lib.cache import project_cache
+        cached = project_cache.get(ctx.projectId)
+        if cached:
+            language = cached.get("language", "python").lower()
+        else:
+            project_doc = db.collection("projects").document(ctx.projectId).get()
+            language = "python"
+            if project_doc.exists:
+                data = project_doc.to_dict()
+                language = data.get("language", "python").lower()
+                project_cache.set(ctx.projectId, data)
         
         test_framework = TEST_FRAMEWORKS.get(language, "appropriate testing framework")
         test_dir = TEST_DIRS.get(language, "tests")
@@ -66,10 +71,11 @@ class TestGeneratorAgent:
                 "- Cover: happy path, edge cases, and error cases.\n"
                 "- Mock external dependencies (databases, HTTP calls) appropriately.\n"
                 "- Each test must have a clear, descriptive name.\n"
+                "- If the implementation is a UI component, write rendering and interaction tests.\n"
                 "- Follow the language's testing conventions."
             )),
             LlmMessage(role="user", content=f"Task: {ctx.taskTitle}\n\nDescription: {ctx.taskDescription}{code_context}"),
-        ])
+        ], max_tokens=8192)
 
         base = re.sub(r"[^a-z0-9]+", "_", ctx.taskTitle.lower()).strip("_")[:50]
         

--- a/apps/server-py/src/lib/cache.py
+++ b/apps/server-py/src/lib/cache.py
@@ -1,0 +1,45 @@
+"""
+Lightweight in-memory LRU cache to avoid redundant Firestore reads.
+Used primarily to cache project language/framework lookups that happen
+3 times per task (once per agent).
+"""
+from collections import OrderedDict
+from threading import Lock
+from typing import Any, Optional
+
+_DEFAULT_MAX = 256
+
+
+class LRUCache:
+    def __init__(self, maxsize: int = _DEFAULT_MAX):
+        self._cache: OrderedDict[str, Any] = OrderedDict()
+        self._maxsize = maxsize
+        self._lock = Lock()
+
+    def get(self, key: str) -> Optional[Any]:
+        with self._lock:
+            if key not in self._cache:
+                return None
+            self._cache.move_to_end(key)
+            return self._cache[key]
+
+    def set(self, key: str, value: Any) -> None:
+        with self._lock:
+            if key in self._cache:
+                self._cache.move_to_end(key)
+            self._cache[key] = value
+            if len(self._cache) > self._maxsize:
+                self._cache.popitem(last=False)
+
+    def delete(self, key: str) -> None:
+        with self._lock:
+            self._cache.pop(key, None)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._cache.clear()
+
+
+# Shared cache instances
+project_cache = LRUCache(maxsize=128)   # project docs keyed by project_id
+task_cache = LRUCache(maxsize=512)      # task docs keyed by task_id

--- a/apps/server-py/src/lib/emitter.py
+++ b/apps/server-py/src/lib/emitter.py
@@ -1,5 +1,6 @@
 from src.lib.socket import sio
 from src.lib.firestore import db
+from src.lib.logger import logger
 from src.lib.utils import now_iso
 from src.lib.socket_events import (
     TaskUpdatedPayload, AgentLogPayload,
@@ -28,8 +29,8 @@ async def emit_agent_log(payload: AgentLogPayload):
             "agentRunId": payload.agentRunId,
             "createdAt": payload.timestamp or now_iso(),
         })
-    except Exception:
-        pass  # Don't fail on logging errors
+    except Exception as e:
+        logger.warning(f"Failed to persist observability log: {e}")
     
     await sio.emit("agent:log", payload.model_dump(), room=_room(payload.projectId))
 

--- a/apps/server-py/src/lib/mcp_server.py
+++ b/apps/server-py/src/lib/mcp_server.py
@@ -1,0 +1,343 @@
+"""
+MCP (Model Context Protocol) server for Autonomous Developer Workspace.
+
+Exposes ADW capabilities as MCP tools and resources so any MCP-compatible
+client (Claude Desktop, Cursor, etc.) can trigger pipelines, read generated
+files, and inspect task history.
+
+Mount point: /mcp  (see main.py)
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from src.lib.firestore import db
+from src.lib.logger import logger
+from src.lib.cache import project_cache, task_cache
+
+mcp = FastMCP(
+    name="autonomous-developer-workspace",
+    instructions=(
+        "ADW gives you tools to generate code, run agent pipelines, and inspect "
+        "project files. Use run_pipeline to execute the full 3-agent pipeline for "
+        "a task, or call individual agents via generate_code / generate_tests / "
+        "review_code. Use the resource URIs to read generated files and task history."
+    ),
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _get_project(project_id: str) -> Optional[dict]:
+    cached = project_cache.get(project_id)
+    if cached:
+        return cached
+    doc = db.collection("projects").document(project_id).get()
+    if not doc.exists:
+        return None
+    data = {"id": doc.id, **doc.to_dict()}
+    project_cache.set(project_id, data)
+    return data
+
+
+def _get_task(task_id: str) -> Optional[dict]:
+    cached = task_cache.get(task_id)
+    if cached:
+        return cached
+    doc = db.collection("tasks").document(task_id).get()
+    if not doc.exists:
+        return None
+    data = {"id": doc.id, **doc.to_dict()}
+    task_cache.set(task_id, data)
+    return data
+
+
+# ── Tools ─────────────────────────────────────────────────────────────────────
+
+@mcp.tool()
+async def run_pipeline(task_id: str) -> dict:
+    """
+    Run the full 3-agent pipeline (code generator → test generator → code reviewer)
+    for a specific task. Returns a summary of each agent's result.
+
+    Args:
+        task_id: The Firestore document ID of the task to run.
+    """
+    from src.agents.agent_dispatcher import dispatch_pipeline
+
+    task = _get_task(task_id)
+    if not task:
+        return {"error": f"Task {task_id} not found"}
+
+    logger.info(f"[MCP] run_pipeline called for task={task_id}")
+    results = await dispatch_pipeline(task_id)
+
+    return {
+        "taskId": task_id,
+        "title": task.get("title"),
+        "stages": [
+            {
+                "agent": r.agentType.value,
+                "status": r.status,
+                "durationMs": r.durationMs,
+                "summary": r.result.summary if r.result else None,
+                "error": r.error,
+            }
+            for r in results
+        ],
+        "overall": "COMPLETED" if all(r.status == "COMPLETED" for r in results) else "FAILED",
+    }
+
+
+@mcp.tool()
+async def generate_code(task_id: str) -> dict:
+    """
+    Run only the Code Generator agent for a task.
+    Returns the generated code content.
+
+    Args:
+        task_id: The Firestore document ID of the task.
+    """
+    from src.agents.agent_dispatcher import dispatch_agent
+    from src.agents.agent_types import AgentType
+
+    task = _get_task(task_id)
+    if not task:
+        return {"error": f"Task {task_id} not found"}
+
+    logger.info(f"[MCP] generate_code called for task={task_id}")
+    result = await dispatch_agent(task_id, AgentType.CODE_GENERATOR)
+
+    if result.status == "FAILED":
+        return {"error": result.error}
+
+    artifacts = [
+        {"filename": a.filename, "language": a.language, "content": a.content}
+        for a in (result.result.artifacts if result.result else [])
+    ]
+    return {"taskId": task_id, "status": "COMPLETED", "artifacts": artifacts}
+
+
+@mcp.tool()
+async def generate_tests(task_id: str, code: Optional[str] = None) -> dict:
+    """
+    Run only the Test Generator agent for a task.
+    Optionally pass existing code to test; otherwise fetches from Firestore.
+
+    Args:
+        task_id: The Firestore document ID of the task.
+        code: Optional implementation code string to generate tests for.
+    """
+    from src.agents.agent_dispatcher import dispatch_agent
+    from src.agents.agent_types import AgentType, AgentResult, Artifact
+
+    task = _get_task(task_id)
+    if not task:
+        return {"error": f"Task {task_id} not found"}
+
+    previous_outputs = {}
+    if code:
+        previous_outputs[AgentType.CODE_GENERATOR] = AgentResult(
+            agentType=AgentType.CODE_GENERATOR,
+            summary="Provided by MCP caller",
+            artifacts=[Artifact(type="code", filename="provided.py", content=code, language="python")],
+            rawLlmOutput=code,
+        )
+
+    logger.info(f"[MCP] generate_tests called for task={task_id}")
+    result = await dispatch_agent(task_id, AgentType.TEST_GENERATOR, previous_outputs)
+
+    if result.status == "FAILED":
+        return {"error": result.error}
+
+    artifacts = [
+        {"filename": a.filename, "language": a.language, "content": a.content}
+        for a in (result.result.artifacts if result.result else [])
+    ]
+    return {"taskId": task_id, "status": "COMPLETED", "artifacts": artifacts}
+
+
+@mcp.tool()
+async def review_code(task_id: str) -> dict:
+    """
+    Run only the Code Reviewer agent for a task.
+    Fetches existing code and test artifacts from Firestore for the task.
+
+    Args:
+        task_id: The Firestore document ID of the task.
+    """
+    from src.agents.agent_dispatcher import dispatch_agent
+    from src.agents.agent_types import AgentType, AgentResult, Artifact
+
+    task = _get_task(task_id)
+    if not task:
+        return {"error": f"Task {task_id} not found"}
+
+    # Pull latest generated files from Firestore to build previous_outputs
+    project_id = task.get("projectId", "")
+    files = list(
+        db.collection("projectFiles")
+        .where("projectId", "==", project_id)
+        .stream()
+    )
+
+    previous_outputs = {}
+    base = task.get("title", "").lower().replace(" ", "_")[:50]
+
+    code_file = next((f for f in files if f.to_dict().get("path", "").endswith(f"{base}.py")), None)
+    test_file = next((f for f in files if f.to_dict().get("path", "").startswith("tests/test_")), None)
+
+    if code_file:
+        d = code_file.to_dict()
+        previous_outputs[AgentType.CODE_GENERATOR] = AgentResult(
+            agentType=AgentType.CODE_GENERATOR,
+            summary="Fetched from Firestore",
+            artifacts=[Artifact(type="code", filename=d["path"], content=d["content"], language=d.get("language", "python"))],
+            rawLlmOutput=d["content"],
+        )
+    if test_file:
+        d = test_file.to_dict()
+        previous_outputs[AgentType.TEST_GENERATOR] = AgentResult(
+            agentType=AgentType.TEST_GENERATOR,
+            summary="Fetched from Firestore",
+            artifacts=[Artifact(type="test", filename=d["path"], content=d["content"], language=d.get("language", "python"))],
+            rawLlmOutput=d["content"],
+        )
+
+    logger.info(f"[MCP] review_code called for task={task_id}")
+    result = await dispatch_agent(task_id, AgentType.CODE_REVIEWER, previous_outputs)
+
+    if result.status == "FAILED":
+        return {"error": result.error}
+
+    review = result.result.artifacts[0].content if result.result and result.result.artifacts else ""
+    return {"taskId": task_id, "status": "COMPLETED", "review": review}
+
+
+@mcp.tool()
+async def list_projects() -> list[dict]:
+    """List all projects with their task counts and status."""
+    projects = list(db.collection("projects").stream())
+    result = []
+    for p in projects:
+        data = p.to_dict()
+        tasks = list(db.collection("tasks").where("projectId", "==", p.id).stream())
+        completed = sum(1 for t in tasks if t.to_dict().get("status") == "COMPLETED")
+        result.append({
+            "id": p.id,
+            "name": data.get("name"),
+            "language": data.get("language", "python"),
+            "taskCount": len(tasks),
+            "completedTasks": completed,
+            "createdAt": data.get("createdAt"),
+        })
+    return result
+
+
+@mcp.tool()
+async def get_task_status(task_id: str) -> dict:
+    """
+    Get the current status and agent run history for a task.
+
+    Args:
+        task_id: The Firestore document ID of the task.
+    """
+    task = _get_task(task_id)
+    if not task:
+        return {"error": f"Task {task_id} not found"}
+
+    runs = list(
+        db.collection("agentRuns")
+        .where("taskId", "==", task_id)
+        .stream()
+    )
+
+    return {
+        "id": task_id,
+        "title": task.get("title"),
+        "status": task.get("status"),
+        "agentRuns": [
+            {
+                "agentType": r.to_dict().get("agentType"),
+                "status": r.to_dict().get("status"),
+                "durationMs": r.to_dict().get("durationMs"),
+            }
+            for r in runs
+        ],
+    }
+
+
+# ── Resources ─────────────────────────────────────────────────────────────────
+
+@mcp.resource("project://{project_id}/files")
+async def get_project_files(project_id: str) -> str:
+    """List all generated files for a project."""
+    files = list(
+        db.collection("projectFiles")
+        .where("projectId", "==", project_id)
+        .stream()
+    )
+    lines = [f"# Files for project {project_id}\n"]
+    for f in files:
+        d = f.to_dict()
+        lines.append(f"- {d.get('path')} ({d.get('language', 'unknown')}, {d.get('size', 0)} bytes)")
+    return "\n".join(lines)
+
+
+@mcp.resource("project://{project_id}/file/{file_path}")
+async def get_file_content(project_id: str, file_path: str) -> str:
+    """Read the content of a specific generated file."""
+    files = list(
+        db.collection("projectFiles")
+        .where("projectId", "==", project_id)
+        .where("path", "==", file_path)
+        .limit(1)
+        .stream()
+    )
+    if not files:
+        return f"File not found: {file_path}"
+    return files[0].to_dict().get("content", "")
+
+
+@mcp.resource("task://{task_id}/review")
+async def get_task_review(task_id: str) -> str:
+    """Read the code review report for a task."""
+    task = _get_task(task_id)
+    if not task:
+        return f"Task {task_id} not found"
+
+    project_id = task.get("projectId", "")
+    base = task.get("title", "").lower().replace(" ", "_")[:50]
+
+    files = list(
+        db.collection("projectFiles")
+        .where("projectId", "==", project_id)
+        .stream()
+    )
+    review = next(
+        (f.to_dict().get("content", "") for f in files
+         if f.to_dict().get("path", "").endswith("_review.md")),
+        None,
+    )
+    return review or f"No review found for task {task_id}"
+
+
+@mcp.resource("project://{project_id}/agent-runs")
+async def get_agent_runs(project_id: str) -> str:
+    """Get all agent run history for a project."""
+    tasks = list(db.collection("tasks").where("projectId", "==", project_id).stream())
+    task_ids = [t.id for t in tasks]
+
+    lines = [f"# Agent Runs for project {project_id}\n"]
+    for task_id in task_ids:
+        runs = list(db.collection("agentRuns").where("taskId", "==", task_id).stream())
+        for r in runs:
+            d = r.to_dict()
+            lines.append(
+                f"- [{d.get('agentType')}] task={task_id} "
+                f"status={d.get('status')} duration={d.get('durationMs')}ms"
+            )
+    return "\n".join(lines)

--- a/apps/server-py/src/main.py
+++ b/apps/server-py/src/main.py
@@ -14,6 +14,7 @@ from src.lib.config import config
 from src.lib.logger import logger
 from src.lib.firestore import db
 from src.lib.socket import sio
+from src.lib.mcp_server import mcp
 from src.agents.agent_service import bootstrap_agents, router as agents_router
 from src.modules.projects.projects_service import router as projects_router
 from src.modules.tasks.tasks_service import router as tasks_router
@@ -70,8 +71,8 @@ async def health():
     try:
         list(db.collection("_health").limit(1).stream())
         db_ok = True
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"Health check DB error: {e}")
     return JSONResponse(
         status_code=200 if db_ok else 503,
         content={
@@ -86,6 +87,9 @@ async def health():
 async def not_found_handler(request: Request, exc: Exception):
     return JSONResponse(status_code=404, content={"error": "Route not found"})
 
+
+# ── Mount MCP ────────────────────────────────────────────────────────────────
+app.mount("/mcp", mcp.streamable_http_app())
 
 # ── Mount Socket.IO ───────────────────────────────────────────────────────────
 socket_app = socketio.ASGIApp(sio, other_asgi_app=app)

--- a/apps/web/src/app/deploy/page.tsx
+++ b/apps/web/src/app/deploy/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { api } from "@/lib/api";
 import { useSocket } from "@/lib/useSocket";
+import { useProjectStore } from "@/lib/useProjectStore";
 import { DeploymentCard } from "@/components/cicd/DeploymentCard";
 import { ProjectSelect } from "@/components/ProjectSelect";
 import type { Deployment } from "@/types";
@@ -16,7 +17,9 @@ export default function DeployPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
 
-  const [selectedId, setSelectedId] = useState(searchParams.get("projectId") ?? "");
+  const { projectId: storedId, setProjectId } = useProjectStore();
+  const urlId = searchParams.get("projectId") ?? "";
+  const [selectedId, setSelectedId] = useState(urlId || storedId);
   const [deployments, setDeployments] = useState<Deployment[]>([]);
   const [loading, setLoading] = useState(false);
   const [triggering, setTriggering] = useState(false);
@@ -35,6 +38,7 @@ export default function DeployPage() {
 
   function handleProjectChange(id: string) {
     setSelectedId(id);
+    setProjectId(id);
     const p = new URLSearchParams();
     if (id) p.set("projectId", id);
     router.replace(`/deploy?${p.toString()}`);

--- a/apps/web/src/app/graph/page.tsx
+++ b/apps/web/src/app/graph/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import dynamic from "next/dynamic";
 import { useTaskGraph } from "@/lib/useTaskGraph";
+import { useProjectStore } from "@/lib/useProjectStore";
 import type { TaskStatus } from "@/types";
 import { AgentLogFeed } from "@/components/AgentLogFeed";
 import { ProjectSelect } from "@/components/ProjectSelect";
@@ -32,9 +33,17 @@ const LEGEND: { status: TaskStatus; label: string }[] = [
 export default function GraphPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const { projectId: storedId, setProjectId } = useProjectStore();
 
-  const [selectedId, setSelectedId] = useState<string>(searchParams.get("projectId") ?? "");
+  // URL param takes priority on first load, then fall back to stored
+  const urlId = searchParams.get("projectId") ?? "";
+  const [selectedId, setSelectedId] = useState<string>(urlId || storedId);
   const [showLogs, setShowLogs] = useState(true);
+
+  // Sync URL → store on mount if URL has an id
+  useEffect(() => {
+    if (urlId && urlId !== storedId) setProjectId(urlId);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { nodes, edges, tasks, loading, error, lastUpdated, socketStatus, refresh, updateTaskStatus } =
     useTaskGraph(selectedId || null);
@@ -42,11 +51,12 @@ export default function GraphPage() {
   const handleSelect = useCallback(
     (id: string) => {
       setSelectedId(id);
+      setProjectId(id);
       const p = new URLSearchParams();
       if (id) p.set("projectId", id);
       router.replace(`/graph?${p.toString()}`);
     },
-    [router],
+    [router, setProjectId],
   );
 
   const completedCount = tasks.filter((t) => t.status === "COMPLETED").length;

--- a/apps/web/src/app/observe/page.tsx
+++ b/apps/web/src/app/observe/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { api } from "@/lib/api";
 import { useSocket } from "@/lib/useSocket";
+import { useProjectStore } from "@/lib/useProjectStore";
 import { ProjectSelect } from "@/components/ProjectSelect";
 import type { SummaryStats, ObsLog, AgentRunRow, TimelineRow } from "@/types";
 import { StatCard } from "@/components/observe/StatCard";
@@ -27,7 +28,13 @@ const AUTO_REFRESH_MS = 10_000;
 
 export default function ObservePage() {
   const [tab, setTab] = useState<Tab>("logs");
-  const [selectedProjectId, setSelectedProjectId] = useState<string>("");
+  const { projectId: storedId, setProjectId } = useProjectStore();
+  const [selectedProjectId, setSelectedProjectId] = useState<string>(storedId);
+
+  const handleProjectChange = useCallback((id: string) => {
+    setSelectedProjectId(id);
+    setProjectId(id);
+  }, [setProjectId]);
   const [stats, setStats]       = useState<SummaryStats | null>(null);
   const [logs, setLogs]         = useState<ObsLog[]>([]);
   const [agents, setAgents]     = useState<AgentRunRow[]>([]);
@@ -85,7 +92,7 @@ export default function ObservePage() {
           <h1 className="text-sm font-medium text-gray-100">Observability</h1>
           <ProjectSelect
             value={selectedProjectId}
-            onChange={setSelectedProjectId}
+            onChange={handleProjectChange}
             placeholder="All Projects (Total)"
             className="border-gray-700 bg-[#252d3d] text-gray-300 text-xs"
           />

--- a/apps/web/src/app/tasks/page.tsx
+++ b/apps/web/src/app/tasks/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { api } from "@/lib/api";
+import { useProjectStore } from "@/lib/useProjectStore";
 import type { Project, Task, TaskStatus } from "@/types";
 import { StatusBadge } from "@/components/StatusBadge";
 import { PageShell } from "@/components/PageShell";
@@ -15,6 +16,7 @@ export default function TasksPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const projectIdParam = searchParams.get("projectId") ?? "";
+  const { projectId: storedId, setProjectId } = useProjectStore();
 
   const [tasks, setTasks] = useState<Task[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
@@ -44,6 +46,7 @@ export default function TasksPage() {
 
   function handleProjectFilter(e: React.ChangeEvent<HTMLSelectElement>) {
     const val = e.target.value;
+    setProjectId(val);
     const params = new URLSearchParams(searchParams.toString());
     if (val) params.set("projectId", val);
     else params.delete("projectId");

--- a/apps/web/src/lib/useProjectStore.ts
+++ b/apps/web/src/lib/useProjectStore.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+const KEY = "adw:selectedProjectId";
+
+function read(): string {
+  if (typeof window === "undefined") return "";
+  return localStorage.getItem(KEY) ?? "";
+}
+
+function write(id: string) {
+  if (typeof window === "undefined") return;
+  if (id) localStorage.setItem(KEY, id);
+  else localStorage.removeItem(KEY);
+}
+
+// In-memory subscribers so all hooks on the same page stay in sync
+const listeners = new Set<(id: string) => void>();
+
+export function useProjectStore() {
+  const [projectId, setProjectIdState] = useState<string>(() => read());
+
+  useEffect(() => {
+    // Sync on mount in case another tab changed it
+    setProjectIdState(read());
+
+    const handler = (id: string) => setProjectIdState(id);
+    listeners.add(handler);
+    return () => { listeners.delete(handler); };
+  }, []);
+
+  const setProjectId = useCallback((id: string) => {
+    write(id);
+    setProjectIdState(id);
+    listeners.forEach((l) => l(id));
+  }, []);
+
+  return { projectId, setProjectId };
+}


### PR DESCRIPTION
a new MCP server at src/lib/mcp_server.py, exposing six core tools including pipeline execution, code and test generation, code review, project listing, and task status tracking. It also adds four structured resources to make project data, file contents, task reviews, and agent run history easily accessible. The server is mounted at /mcp using streamable_http_app(), making it ready for integration with external tooling and workflows.

To improve performance and reduce redundant database access, an LRU cache layer has been added in src/lib/cache.py. The project_cache removes repeated language lookups during task pipelines, while the task_cache prevents duplicate task fetches in the dispatcher. Cache entries are automatically invalidated whenever a task status changes, ensuring consistency without sacrificing speed.

This also resolves several reliability issues. Agent failures on frontend tasks are addressed by increasing token limits to 8192 and enforcing a single file constraint for UI generation. Project selection state is now persisted via localStorage in useProjectStore.ts, ensuring consistency across graph, deploy, observe, and tasks pages. Additionally, exception handling has been improved by removing silent failures and enabling better logging with exc_info=True. Finally, MCP CLI support has been added to dependencies for easier local development and testing.